### PR TITLE
converted project to use retrofit2 with optional custom OkHttpClient

### DIFF
--- a/loggliest/build.gradle
+++ b/loggliest/build.gradle
@@ -18,7 +18,9 @@ android {
 }
 
 dependencies {
-    compile 'com.squareup.retrofit:retrofit:1.9.0'
+    compile 'com.squareup.retrofit2:retrofit:2.3.0'
+    // for converting responses to scalar Strings
+    compile 'com.squareup.retrofit2:converter-scalars:2.3.0'
 }
 
 apply plugin: 'maven'


### PR DESCRIPTION
Changed the project to use retrofit 2/okHttp 3, which many new projects are converting to.  I noticed that the project hasn't been updated in two years so I thought I would throw this over to you and see what you think.

You can customize the OkHttpClient to use (for instance, to override connection/read timeouts among other things) using Builder.okHttpClient().  If this is not specified it uses a client with default settings.